### PR TITLE
Set up MongoDB storage

### DIFF
--- a/src/main/java/edu/northeastern/cs5500/starterbot/controller/UserPreferenceController.java
+++ b/src/main/java/edu/northeastern/cs5500/starterbot/controller/UserPreferenceController.java
@@ -20,14 +20,6 @@ public class UserPreferenceController {
     @Inject
     UserPreferenceController(GenericRepository<UserPreference> userPreferenceRepository) {
         this.userPreferenceRepository = userPreferenceRepository;
-
-        if (userPreferenceRepository.count() == 0) {
-            UserPreference userPreference = new UserPreference();
-            userPreference.setDiscordUserId("1234");
-            userPreference.setPreferredName("Alex");
-            userPreferenceRepository.add(userPreference);
-        }
-
         openTelemetry = new FakeOpenTelemetryService();
     }
 

--- a/src/main/java/edu/northeastern/cs5500/starterbot/repository/RepositoryModule.java
+++ b/src/main/java/edu/northeastern/cs5500/starterbot/repository/RepositoryModule.java
@@ -6,22 +6,14 @@ import edu.northeastern.cs5500.starterbot.model.UserPreference;
 
 @Module
 public class RepositoryModule {
-    // NOTE: You can use the following lines if you'd like to store objects in memory.
-    // NOTE: The presence of commented-out code in your project *will* result in a lowered grade.
     @Provides
     public GenericRepository<UserPreference> provideUserPreferencesRepository(
-            InMemoryRepository<UserPreference> repository) {
+            MongoDBRepository<UserPreference> repository) {
         return repository;
     }
 
-    // @Provides
-    // public GenericRepository<UserPreference> provideUserPreferencesRepository(
-    //         MongoDBRepository<UserPreference> repository) {
-    //     return repository;
-    // }
-
-    // @Provides
-    // public Class<UserPreference> provideUserPreference() {
-    //     return UserPreference.class;
-    // }
+    @Provides
+    public Class<UserPreference> provideUserPreference() {
+        return UserPreference.class;
+    }
 }

--- a/src/main/java/edu/northeastern/cs5500/starterbot/service/MongoDBService.java
+++ b/src/main/java/edu/northeastern/cs5500/starterbot/service/MongoDBService.java
@@ -46,7 +46,14 @@ public class MongoDBService implements Service {
                         .build();
 
         MongoClient mongoClient = MongoClients.create(mongoClientSettings);
-        mongoDatabase = mongoClient.getDatabase(connectionString.getDatabase());
+
+        String databaseName = connectionString.getDatabase();
+
+        if (databaseName == null || databaseName.equals("")) {
+            ProcessBuilder processBuilder = new ProcessBuilder();
+            databaseName = processBuilder.environment().get("MONGODB_DATABASE_NAME");
+        }
+        mongoDatabase = mongoClient.getDatabase(databaseName);
     }
 
     @Override


### PR DESCRIPTION
Note that after merging this change everyone will need `MONGODB_URI` and `MONGODB_DATABASE_NAME` set; suggest that `MONGODB_DATABASE_NAME` is set to `development` for now.

Removed demo objects in the UserPreferenceController since the database now persists in between runs.

Added a way to set the database name if it isn't set as part of `MONGODB_URI` - the URI overrides the environment variable for now.

Closes #3